### PR TITLE
PieChart.php PHP 8.1.2 Fatal error

### DIFF
--- a/libchart/classes/view/chart/PieChart.php
+++ b/libchart/classes/view/chart/PieChart.php
@@ -64,9 +64,15 @@
          * @return integer result of the comparison
          */
         protected function sortPie($v1, $v2) {
-            return $v1[0] == $v2[0] ? 0 :
-                $v1[0] > $v2[0] ? -1 :
-                1;
+            if ($v1[0] == $v2[0]) {
+                return 0;
+            }
+            
+            if ($v1[0] > $v2[0]) {
+                return -1;
+            }
+            
+            return 1;
         }
         
         /**


### PR DESCRIPTION
Fix for the following error (PHP version 8.1.2):

PHP Fatal error: Unparenthesized a ? b : c ? d : e is not supported.
Use either (a ? b : c) ? d : e or a ? b : (c ? d : e) in /libchart/classes/view/chart/PieChart.php on line 67